### PR TITLE
Feat: handle account disconnected

### DIFF
--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -31,6 +31,7 @@ export const initialise: () => Promise<void> = async () => {
     // Get the initial WNFS appState
     const initialAppState = await walletauth.app({
       onAccountChange: newAppState => handleAppState(newAppState),
+      onDisconnect: () => disconnect(),
     })
 
     // Populate session and filesystem stores

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,7 +10,10 @@
   import Notifications from '$components/notifications/Notifications.svelte'
   import Header from '$components/Header.svelte'
 
-  onMount(() => { setDevice() })
+  onMount(async () => {
+    await initialise()
+    setDevice()
+  })
 
   const setDevice = () => {
     if (window.innerWidth <= TABLET_WIDTH) {
@@ -19,8 +22,6 @@
       deviceStore.set({ isMobile: false })
     }
   }
-
-  initialise()
 </script>
 
 <svelte:head>


### PR DESCRIPTION
# Description

Adding an `onDisconnect` callback to `walletauth.app` to ensure the app disconnected when metamask or the `walletauth` package detect a disconnection

## Link to issue

N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)


