### PR TITLE
Feat: upgrade sveltekit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
         "webnative-walletauth": "^0.2.0"
       },
       "devDependencies": {
-        "@sveltejs/adapter-static": "1.0.0-next.43",
-        "@sveltejs/kit": "1.0.0-next.489",
+        "@sveltejs/adapter-static": "^1.0.0",
+        "@sveltejs/kit": "^1.0.1",
         "autoprefixer": "^10.4.4",
         "buffer": "^6.0.3",
         "daisyui": "^2.0.2",
@@ -18,19 +18,371 @@
         "events": "^3.3.0",
         "node-fetch": "*",
         "postcss": "^8.4.12",
-        "svelte": "^3.44.0",
-        "svelte-check": "^2.7.1",
-        "svelte-preprocess": "^4.10.6",
+        "svelte": "^3.34.0",
+        "svelte-check": "^2.0.0",
+        "svelte-preprocess": "^4.0.0",
         "tailwindcss": "^3.0.24",
         "typescript": "^4.5.4",
         "undici": "*",
-        "vite": "^3.1.0-beta.1"
+        "vite": "^4.0.0"
       }
     },
     "node_modules/@chainsafe/is-ip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
       "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.14.tgz",
+      "integrity": "sha512-u0rITLxFIeYAvtJXBQNhNuV4YZe+MD1YvIWT7Nicj8hZAtRVZk2PgNH6KclcKDVHz1ChLKXRfX7d7tkbQBUfrg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.14.tgz",
+      "integrity": "sha512-hTqB6Iq13pW4xaydeqQrs8vPntUnMjbkq+PgGiBMi69eYk74naG2ftHWqKnxn874kNrt5Or3rQ0PJutx2doJuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.14.tgz",
+      "integrity": "sha512-jir51K4J0K5Rt0KOcippjSNdOl7akKDVz5I6yrqdk4/m9y+rldGptQUF7qU4YpX8U61LtR+w2Tu2Ph+K/UaJOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.14.tgz",
+      "integrity": "sha512-vrlaP81IuwPaw1fyX8fHCmivP3Gr73ojVEZy+oWJLAiZVcG8o8Phwun/XDnYIFUHxIoUnMFEpg9o38MIvlw8zw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.14.tgz",
+      "integrity": "sha512-KV1E01eC2hGYA2qzFDRCK4wdZCRUvMwCNcobgpiiOzp5QXpJBqFPdxI69j8vvzuU7oxFXDgANwEkXvpeQqyOyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.14.tgz",
+      "integrity": "sha512-xRM1RQsazSvL42BNa5XC7ytD4ZDp0ZyJcH7aB0SlYUcHexJUKiDNKR7dlRVlpt6W0DvoRPU2nWK/9/QWS4u2fw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.14.tgz",
+      "integrity": "sha512-7ALTAn6YRRf1O6fw9jmn0rWmOx3XfwDo7njGtjy1LXhDGUjTY/vohEPM3ii5MQ411vJv1r498EEx2aBQTJcrEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.14.tgz",
+      "integrity": "sha512-X6xULug66ulrr4IzrW7qq+eq9n4MtEyagdWvj4o4cmWr+JXOT47atjpDF9j5M2zHY0UQBmqnHhwl+tXpkpIb2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.14.tgz",
+      "integrity": "sha512-TLh2OcbBUQcMYRH4GbiDkDZfZ4t1A3GgmeXY27dHSI6xrU7IkO00MGBiJySmEV6sH3Wa6pAN6UtaVL0DwkGW4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.14.tgz",
+      "integrity": "sha512-oBZkcZ56UZDFCAfE3Fd/Jgy10EoS7Td77NzNGenM+HSY8BkdQAcI9VF9qgwdOLZ+tuftWD7UqZ26SAhtvA3XhA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.14.tgz",
+      "integrity": "sha512-udz/aEHTcuHP+xdWOJmZ5C9RQXHfZd/EhCnTi1Hfay37zH3lBxn/fNs85LA9HlsniFw2zccgcbrrTMKk7Cn1Qg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.14.tgz",
+      "integrity": "sha512-kJ2iEnikUOdC1SiTGbH0fJUgpZwa0ITDTvj9EHf9lm3I0hZ4Yugsb3M6XSl696jVxrEocLe519/8CbSpQWFSrg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.14.tgz",
+      "integrity": "sha512-kclKxvZvX5YhykwlJ/K9ljiY4THe5vXubXpWmr7q3Zu3WxKnUe1VOZmhkEZlqtnJx31GHPEV4SIG95IqTdfgfg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.14.tgz",
+      "integrity": "sha512-fdwP9Dc+Kx/cZwp9T9kNqjAE/PQjfrxbio4rZ3XnC3cVvZBjuxpkiyu/tuCwt6SbAK5th6AYNjFdEV9kGC020A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.14.tgz",
+      "integrity": "sha512-++fw3P4fQk9nqvdzbANRqimKspL8pDCnSpXomyhV7V/ISha/BZIYvZwLBWVKp9CVWKwWPJ4ktsezuLIvlJRHqA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.14.tgz",
+      "integrity": "sha512-TomtswAuzBf2NnddlrS4W01Tv85RM9YtATB3OugY6On0PLM4Ksz5qvQKVAjtzPKoLgL1FiZtfc8mkZc4IgoMEA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.14.tgz",
+      "integrity": "sha512-U06pfx8P5CqyoPNfqIJmnf+5/r4mJ1S62G4zE6eOjS59naQcxi6GnscUCPH3b+hRG0qdKoGX49RAyiqW+M9aSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.14.tgz",
+      "integrity": "sha512-/Jl8XVaWEZNu9rZw+n792GIBupQwHo6GDoapHSb/2xp/Ku28eK6QpR2O9cPBkzHH4OOoMH0LB6zg/qczJ5TTGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.14.tgz",
+      "integrity": "sha512-2iI7D34uTbDn/TaSiUbEHz+fUa8KbN90vX5yYqo12QGpu6T8Jl+kxODsWuMCwoTVlqUpwfPV22nBbFPME9OPtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.14.tgz",
+      "integrity": "sha512-SjlM7AHmQVTiGBJE/nqauY1aDh80UBsXZ94g4g60CDkrDMseatiqALVcIuElg4ZSYzJs8hsg5W6zS2zLpZTVgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.14.tgz",
+      "integrity": "sha512-z06t5zqk8ak0Xom5HG81z2iOQ1hNWYsFQp3sczVLVx+dctWdgl80tNRyTbwjaFfui2vFO12dfE3trCTvA+HO4g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.14.tgz",
+      "integrity": "sha512-ED1UpWcM6lAbalbbQ9TrGqJh4Y9TaASUvu8bI/0mgJcxhSByJ6rbpgqRhxYMaQ682WfA71nxUreaTO7L275zrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@ipld/dag-cbor": {
       "version": "8.0.0",
@@ -394,68 +746,65 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@sveltejs/adapter-static": {
-      "version": "1.0.0-next.43",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.43.tgz",
-      "integrity": "sha512-PAgSp1GA8HkYE4p30/sBvJme2nefhcTBJafqQdMNoUksWZF2WzuL8OEO8wa9ndE6cghcGk3j6Ve0Oskg/wtTOw==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0.tgz",
+      "integrity": "sha512-ZrQhRgSa2TsH+zvrOIKpdVsAhExafpsn+w6Gv1WHzV76RZ2XOYFa8xi6hEzRjeeAL++ac0dsZHzp8M4X7YIabg==",
+      "dev": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^1.0.0"
+      }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.489",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.489.tgz",
-      "integrity": "sha512-7oag1fimI9f8e8mNy2wQRgMCXSov5dASqeTdXffgnptWBpuEjr8myffJ9djoRVQXoFjCja39lCHBo239iY8+KA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.3.tgz",
+      "integrity": "sha512-Mv6KSeJTvHC6RIuLDMPZ8E60zafmyMHjjoXXKwRnD0gdTGdNqnkTd8D9KdJe6zOKKkz7ccldbCtsWW4/XPwgmg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.5",
+        "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^3.1.2",
-        "kleur": "^4.1.4",
-        "magic-string": "^0.26.2",
+        "devalue": "^4.2.0",
+        "esm-env": "^1.0.0",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.27.0",
         "mime": "^3.0.0",
-        "node-fetch": "^3.2.4",
         "sade": "^1.8.1",
-        "set-cookie-parser": "^2.4.8",
+        "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "^5.8.1"
+        "undici": "5.14.0"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": "^16.14 || >=18"
       },
       "peerDependencies": {
-        "svelte": "^3.44.0",
-        "vite": "^3.1.0"
+        "svelte": "^3.54.0",
+        "vite": "^4.0.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.3.1.tgz",
-      "integrity": "sha512-2Uu2sDdIR+XQWF7QWOVSF2jR9EU6Ciw1yWfYnfLYj8HIgnNxkh/8g22Fw2pBUI8QNyW/KxtqJUWBI+8ypamSrQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.2.tgz",
+      "integrity": "sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "deepmerge": "^4.2.2",
         "kleur": "^4.1.5",
-        "magic-string": "^0.26.7",
+        "magic-string": "^0.27.0",
         "svelte-hmr": "^0.15.1",
-        "vitefu": "^0.2.2"
+        "vitefu": "^0.2.3"
       },
       "engines": {
         "node": "^14.18.0 || >= 16"
       },
       "peerDependencies": {
-        "diff-match-patch": "^1.0.5",
-        "svelte": "^3.44.0",
-        "vite": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "diff-match-patch": {
-          "optional": true
-        }
+        "svelte": "^3.54.0",
+        "vite": "^4.0.0"
       }
     },
     "node_modules/@types/cookie": {
@@ -1128,9 +1477,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-3.1.3.tgz",
-      "integrity": "sha512-9KO89Cb+qjzf2CqdrH+NuLaqdk9GhDP5EhR4zlkR51dvuIaiqtlkDkGzLMShDemwUy21raSMdu+kpX8Enw3yGQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.2.0.tgz",
+      "integrity": "sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==",
       "dev": true
     },
     "node_modules/didyoumean": {
@@ -1186,9 +1535,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
-      "integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.14.tgz",
+      "integrity": "sha512-6xAn3O6ZZyoxZAEkwfI9hw4cEqSr/o1ViJtnkvImVkblmUN65Md04o0S/7H1WNu1XGf1Cjij/on7VO4psIYjkw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1198,44 +1547,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.15.15",
-        "@esbuild/linux-loong64": "0.15.15",
-        "esbuild-android-64": "0.15.15",
-        "esbuild-android-arm64": "0.15.15",
-        "esbuild-darwin-64": "0.15.15",
-        "esbuild-darwin-arm64": "0.15.15",
-        "esbuild-freebsd-64": "0.15.15",
-        "esbuild-freebsd-arm64": "0.15.15",
-        "esbuild-linux-32": "0.15.15",
-        "esbuild-linux-64": "0.15.15",
-        "esbuild-linux-arm": "0.15.15",
-        "esbuild-linux-arm64": "0.15.15",
-        "esbuild-linux-mips64le": "0.15.15",
-        "esbuild-linux-ppc64le": "0.15.15",
-        "esbuild-linux-riscv64": "0.15.15",
-        "esbuild-linux-s390x": "0.15.15",
-        "esbuild-netbsd-64": "0.15.15",
-        "esbuild-openbsd-64": "0.15.15",
-        "esbuild-sunos-64": "0.15.15",
-        "esbuild-windows-32": "0.15.15",
-        "esbuild-windows-64": "0.15.15",
-        "esbuild-windows-arm64": "0.15.15"
-      }
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
-      "integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
+        "@esbuild/android-arm": "0.16.14",
+        "@esbuild/android-arm64": "0.16.14",
+        "@esbuild/android-x64": "0.16.14",
+        "@esbuild/darwin-arm64": "0.16.14",
+        "@esbuild/darwin-x64": "0.16.14",
+        "@esbuild/freebsd-arm64": "0.16.14",
+        "@esbuild/freebsd-x64": "0.16.14",
+        "@esbuild/linux-arm": "0.16.14",
+        "@esbuild/linux-arm64": "0.16.14",
+        "@esbuild/linux-ia32": "0.16.14",
+        "@esbuild/linux-loong64": "0.16.14",
+        "@esbuild/linux-mips64el": "0.16.14",
+        "@esbuild/linux-ppc64": "0.16.14",
+        "@esbuild/linux-riscv64": "0.16.14",
+        "@esbuild/linux-s390x": "0.16.14",
+        "@esbuild/linux-x64": "0.16.14",
+        "@esbuild/netbsd-x64": "0.16.14",
+        "@esbuild/openbsd-x64": "0.16.14",
+        "@esbuild/sunos-x64": "0.16.14",
+        "@esbuild/win32-arm64": "0.16.14",
+        "@esbuild/win32-ia32": "0.16.14",
+        "@esbuild/win32-x64": "0.16.14"
       }
     },
     "node_modules/escalade": {
@@ -1246,6 +1579,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/esm-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
+      "integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
+      "dev": true
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
@@ -2101,12 +2440,12 @@
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/magic-string": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
       "dev": true,
       "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.13"
       },
       "engines": {
         "node": ">=12"
@@ -2485,9 +2824,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
       "dev": true,
       "funding": [
         {
@@ -2766,15 +3105,16 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
+      "integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -2981,9 +3321,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.53.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
-      "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
+      "integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -3246,9 +3586,9 @@
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/undici": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
+      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -3294,15 +3634,15 @@
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "node_modules/vite": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
-      "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
+      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.15.9",
-        "postcss": "^8.4.18",
+        "esbuild": "^0.16.3",
+        "postcss": "^8.4.20",
         "resolve": "^1.22.1",
-        "rollup": "^2.79.1"
+        "rollup": "^3.7.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3343,12 +3683,12 @@
       }
     },
     "node_modules/vitefu": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.2.tgz",
-      "integrity": "sha512-8CKEIWPm4B4DUDN+h+hVJa9pyNi7rzc5MYmbxhs1wcMakueGFNWB5/DL30USm9qU3xUPnL4/rrLEAwwFiD1tag==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.4.tgz",
+      "integrity": "sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==",
       "dev": true,
       "peerDependencies": {
-        "vite": "^3.0.0"
+        "vite": "^3.0.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "vite": {
@@ -3474,6 +3814,160 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
       "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
+    },
+    "@esbuild/android-arm": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.14.tgz",
+      "integrity": "sha512-u0rITLxFIeYAvtJXBQNhNuV4YZe+MD1YvIWT7Nicj8hZAtRVZk2PgNH6KclcKDVHz1ChLKXRfX7d7tkbQBUfrg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.14.tgz",
+      "integrity": "sha512-hTqB6Iq13pW4xaydeqQrs8vPntUnMjbkq+PgGiBMi69eYk74naG2ftHWqKnxn874kNrt5Or3rQ0PJutx2doJuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.14.tgz",
+      "integrity": "sha512-jir51K4J0K5Rt0KOcippjSNdOl7akKDVz5I6yrqdk4/m9y+rldGptQUF7qU4YpX8U61LtR+w2Tu2Ph+K/UaJOw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.14.tgz",
+      "integrity": "sha512-vrlaP81IuwPaw1fyX8fHCmivP3Gr73ojVEZy+oWJLAiZVcG8o8Phwun/XDnYIFUHxIoUnMFEpg9o38MIvlw8zw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.14.tgz",
+      "integrity": "sha512-KV1E01eC2hGYA2qzFDRCK4wdZCRUvMwCNcobgpiiOzp5QXpJBqFPdxI69j8vvzuU7oxFXDgANwEkXvpeQqyOyg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.14.tgz",
+      "integrity": "sha512-xRM1RQsazSvL42BNa5XC7ytD4ZDp0ZyJcH7aB0SlYUcHexJUKiDNKR7dlRVlpt6W0DvoRPU2nWK/9/QWS4u2fw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.14.tgz",
+      "integrity": "sha512-7ALTAn6YRRf1O6fw9jmn0rWmOx3XfwDo7njGtjy1LXhDGUjTY/vohEPM3ii5MQ411vJv1r498EEx2aBQTJcrEw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.14.tgz",
+      "integrity": "sha512-X6xULug66ulrr4IzrW7qq+eq9n4MtEyagdWvj4o4cmWr+JXOT47atjpDF9j5M2zHY0UQBmqnHhwl+tXpkpIb2w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.14.tgz",
+      "integrity": "sha512-TLh2OcbBUQcMYRH4GbiDkDZfZ4t1A3GgmeXY27dHSI6xrU7IkO00MGBiJySmEV6sH3Wa6pAN6UtaVL0DwkGW4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.14.tgz",
+      "integrity": "sha512-oBZkcZ56UZDFCAfE3Fd/Jgy10EoS7Td77NzNGenM+HSY8BkdQAcI9VF9qgwdOLZ+tuftWD7UqZ26SAhtvA3XhA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.14.tgz",
+      "integrity": "sha512-udz/aEHTcuHP+xdWOJmZ5C9RQXHfZd/EhCnTi1Hfay37zH3lBxn/fNs85LA9HlsniFw2zccgcbrrTMKk7Cn1Qg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.14.tgz",
+      "integrity": "sha512-kJ2iEnikUOdC1SiTGbH0fJUgpZwa0ITDTvj9EHf9lm3I0hZ4Yugsb3M6XSl696jVxrEocLe519/8CbSpQWFSrg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.14.tgz",
+      "integrity": "sha512-kclKxvZvX5YhykwlJ/K9ljiY4THe5vXubXpWmr7q3Zu3WxKnUe1VOZmhkEZlqtnJx31GHPEV4SIG95IqTdfgfg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.14.tgz",
+      "integrity": "sha512-fdwP9Dc+Kx/cZwp9T9kNqjAE/PQjfrxbio4rZ3XnC3cVvZBjuxpkiyu/tuCwt6SbAK5th6AYNjFdEV9kGC020A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.14.tgz",
+      "integrity": "sha512-++fw3P4fQk9nqvdzbANRqimKspL8pDCnSpXomyhV7V/ISha/BZIYvZwLBWVKp9CVWKwWPJ4ktsezuLIvlJRHqA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.14.tgz",
+      "integrity": "sha512-TomtswAuzBf2NnddlrS4W01Tv85RM9YtATB3OugY6On0PLM4Ksz5qvQKVAjtzPKoLgL1FiZtfc8mkZc4IgoMEA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.14.tgz",
+      "integrity": "sha512-U06pfx8P5CqyoPNfqIJmnf+5/r4mJ1S62G4zE6eOjS59naQcxi6GnscUCPH3b+hRG0qdKoGX49RAyiqW+M9aSw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.14.tgz",
+      "integrity": "sha512-/Jl8XVaWEZNu9rZw+n792GIBupQwHo6GDoapHSb/2xp/Ku28eK6QpR2O9cPBkzHH4OOoMH0LB6zg/qczJ5TTGg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.14.tgz",
+      "integrity": "sha512-2iI7D34uTbDn/TaSiUbEHz+fUa8KbN90vX5yYqo12QGpu6T8Jl+kxODsWuMCwoTVlqUpwfPV22nBbFPME9OPtw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.14.tgz",
+      "integrity": "sha512-SjlM7AHmQVTiGBJE/nqauY1aDh80UBsXZ94g4g60CDkrDMseatiqALVcIuElg4ZSYzJs8hsg5W6zS2zLpZTVgg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.14.tgz",
+      "integrity": "sha512-z06t5zqk8ak0Xom5HG81z2iOQ1hNWYsFQp3sczVLVx+dctWdgl80tNRyTbwjaFfui2vFO12dfE3trCTvA+HO4g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.14.tgz",
+      "integrity": "sha512-ED1UpWcM6lAbalbbQ9TrGqJh4Y9TaASUvu8bI/0mgJcxhSByJ6rbpgqRhxYMaQ682WfA71nxUreaTO7L275zrw==",
+      "dev": true,
+      "optional": true
     },
     "@ipld/dag-cbor": {
       "version": "8.0.0",
@@ -3758,44 +4252,45 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@sveltejs/adapter-static": {
-      "version": "1.0.0-next.43",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.43.tgz",
-      "integrity": "sha512-PAgSp1GA8HkYE4p30/sBvJme2nefhcTBJafqQdMNoUksWZF2WzuL8OEO8wa9ndE6cghcGk3j6Ve0Oskg/wtTOw==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0.tgz",
+      "integrity": "sha512-ZrQhRgSa2TsH+zvrOIKpdVsAhExafpsn+w6Gv1WHzV76RZ2XOYFa8xi6hEzRjeeAL++ac0dsZHzp8M4X7YIabg==",
+      "dev": true,
+      "requires": {}
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.489",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.489.tgz",
-      "integrity": "sha512-7oag1fimI9f8e8mNy2wQRgMCXSov5dASqeTdXffgnptWBpuEjr8myffJ9djoRVQXoFjCja39lCHBo239iY8+KA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.3.tgz",
+      "integrity": "sha512-Mv6KSeJTvHC6RIuLDMPZ8E60zafmyMHjjoXXKwRnD0gdTGdNqnkTd8D9KdJe6zOKKkz7ccldbCtsWW4/XPwgmg==",
       "dev": true,
       "requires": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.5",
+        "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^3.1.2",
-        "kleur": "^4.1.4",
-        "magic-string": "^0.26.2",
+        "devalue": "^4.2.0",
+        "esm-env": "^1.0.0",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.27.0",
         "mime": "^3.0.0",
-        "node-fetch": "^3.2.4",
         "sade": "^1.8.1",
-        "set-cookie-parser": "^2.4.8",
+        "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "^5.8.1"
+        "undici": "5.14.0"
       }
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.3.1.tgz",
-      "integrity": "sha512-2Uu2sDdIR+XQWF7QWOVSF2jR9EU6Ciw1yWfYnfLYj8HIgnNxkh/8g22Fw2pBUI8QNyW/KxtqJUWBI+8ypamSrQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.2.tgz",
+      "integrity": "sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==",
       "dev": true,
       "requires": {
         "debug": "^4.3.4",
         "deepmerge": "^4.2.2",
         "kleur": "^4.1.5",
-        "magic-string": "^0.26.7",
+        "magic-string": "^0.27.0",
         "svelte-hmr": "^0.15.1",
-        "vitefu": "^0.2.2"
+        "vitefu": "^0.2.3"
       }
     },
     "@types/cookie": {
@@ -4263,9 +4758,9 @@
       }
     },
     "devalue": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-3.1.3.tgz",
-      "integrity": "sha512-9KO89Cb+qjzf2CqdrH+NuLaqdk9GhDP5EhR4zlkR51dvuIaiqtlkDkGzLMShDemwUy21raSMdu+kpX8Enw3yGQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.2.0.tgz",
+      "integrity": "sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==",
       "dev": true
     },
     "didyoumean": {
@@ -4317,46 +4812,45 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.15.tgz",
-      "integrity": "sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==",
+      "version": "0.16.14",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.14.tgz",
+      "integrity": "sha512-6xAn3O6ZZyoxZAEkwfI9hw4cEqSr/o1ViJtnkvImVkblmUN65Md04o0S/7H1WNu1XGf1Cjij/on7VO4psIYjkw==",
       "dev": true,
       "requires": {
-        "@esbuild/android-arm": "0.15.15",
-        "@esbuild/linux-loong64": "0.15.15",
-        "esbuild-android-64": "0.15.15",
-        "esbuild-android-arm64": "0.15.15",
-        "esbuild-darwin-64": "0.15.15",
-        "esbuild-darwin-arm64": "0.15.15",
-        "esbuild-freebsd-64": "0.15.15",
-        "esbuild-freebsd-arm64": "0.15.15",
-        "esbuild-linux-32": "0.15.15",
-        "esbuild-linux-64": "0.15.15",
-        "esbuild-linux-arm": "0.15.15",
-        "esbuild-linux-arm64": "0.15.15",
-        "esbuild-linux-mips64le": "0.15.15",
-        "esbuild-linux-ppc64le": "0.15.15",
-        "esbuild-linux-riscv64": "0.15.15",
-        "esbuild-linux-s390x": "0.15.15",
-        "esbuild-netbsd-64": "0.15.15",
-        "esbuild-openbsd-64": "0.15.15",
-        "esbuild-sunos-64": "0.15.15",
-        "esbuild-windows-32": "0.15.15",
-        "esbuild-windows-64": "0.15.15",
-        "esbuild-windows-arm64": "0.15.15"
+        "@esbuild/android-arm": "0.16.14",
+        "@esbuild/android-arm64": "0.16.14",
+        "@esbuild/android-x64": "0.16.14",
+        "@esbuild/darwin-arm64": "0.16.14",
+        "@esbuild/darwin-x64": "0.16.14",
+        "@esbuild/freebsd-arm64": "0.16.14",
+        "@esbuild/freebsd-x64": "0.16.14",
+        "@esbuild/linux-arm": "0.16.14",
+        "@esbuild/linux-arm64": "0.16.14",
+        "@esbuild/linux-ia32": "0.16.14",
+        "@esbuild/linux-loong64": "0.16.14",
+        "@esbuild/linux-mips64el": "0.16.14",
+        "@esbuild/linux-ppc64": "0.16.14",
+        "@esbuild/linux-riscv64": "0.16.14",
+        "@esbuild/linux-s390x": "0.16.14",
+        "@esbuild/linux-x64": "0.16.14",
+        "@esbuild/netbsd-x64": "0.16.14",
+        "@esbuild/openbsd-x64": "0.16.14",
+        "@esbuild/sunos-x64": "0.16.14",
+        "@esbuild/win32-arm64": "0.16.14",
+        "@esbuild/win32-ia32": "0.16.14",
+        "@esbuild/win32-x64": "0.16.14"
       }
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.15.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.15.tgz",
-      "integrity": "sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==",
-      "dev": true,
-      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "esm-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
+      "integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
       "dev": true
     },
     "eventemitter3": {
@@ -4985,12 +5479,12 @@
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "magic-string": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.13"
       }
     },
     "merge-options": {
@@ -5241,9 +5735,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
@@ -5415,9 +5909,9 @@
       }
     },
     "rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
+      "integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -5562,9 +6056,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.53.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.1.tgz",
-      "integrity": "sha512-Q4/hHkktZogGhN5iqxqSi9sjEVoe/NbIxX4hXEHoasTxj+TxEQVAq66LnDMdAZxjmsodkoI5F3slqsS68U7FNw==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
+      "integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
       "dev": true
     },
     "svelte-check": {
@@ -5732,9 +6226,9 @@
       }
     },
     "undici": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
+      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
       "requires": {
         "busboy": "^1.6.0"
       }
@@ -5761,22 +6255,22 @@
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "vite": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
-      "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
+      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.15.9",
+        "esbuild": "^0.16.3",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.18",
+        "postcss": "^8.4.20",
         "resolve": "^1.22.1",
-        "rollup": "^2.79.1"
+        "rollup": "^3.7.0"
       }
     },
     "vitefu": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.2.tgz",
-      "integrity": "sha512-8CKEIWPm4B4DUDN+h+hVJa9pyNi7rzc5MYmbxhs1wcMakueGFNWB5/DL30USm9qU3xUPnL4/rrLEAwwFiD1tag==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.4.tgz",
+      "integrity": "sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "format": "prettier --write --plugin-search-dir=. ."
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "1.0.0-next.43",
-    "@sveltejs/kit": "1.0.0-next.489",
+    "@sveltejs/adapter-static": "^1.0.0",
+    "@sveltejs/kit": "^1.0.1",
     "autoprefixer": "^10.4.4",
     "buffer": "^6.0.3",
     "daisyui": "^2.0.2",
@@ -20,13 +20,13 @@
     "events": "^3.3.0",
     "node-fetch": "*",
     "postcss": "^8.4.12",
-    "svelte": "^3.44.0",
-    "svelte-check": "^2.7.1",
-    "svelte-preprocess": "^4.10.6",
+    "svelte": "^3.34.0",
+    "svelte-check": "^2.0.0",
+    "svelte-preprocess": "^4.0.0",
     "tailwindcss": "^3.0.24",
     "typescript": "^4.5.4",
     "undici": "*",
-    "vite": "^3.1.0-beta.1"
+    "vite": "^4.0.0"
   },
   "dependencies": {
     "webnative": "^0.35.1",

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,3 +1,4 @@
 export const csr = true
 export const ssr = false
 export const prerender = true
+export const trailingSlash = 'always'

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -10,7 +10,6 @@ const config = {
     adapter: adapter({
       fallback: 'index.html'
     }),
-    trailingSlash: 'always',
   }
 }
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   mode: 'jit',
   content: ['./src/**/*.{html,js,svelte,ts}'],
+  safelist: ['alert-success', 'alert-error', 'alert-info', 'alert-warning'],
   plugins: [require('daisyui')],
   darkMode: ['class', '[data-theme="dark"]'],
   daisyui: {
@@ -121,11 +122,6 @@ module.exports = {
       zIndex: {
         max: '1000' // High enough to appear above the modal(999)
       }
-    }
-  },
-  purge: {
-    options: {
-      safelist: ['alert-success', 'alert-error', 'alert-info', 'alert-warning']
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,13 @@
 		"allowJs": true,
 		"checkJs": true,
 		"paths": {
+			"$components": ["src/components"],
 			"$components/*": ["src/components/*"],
+			"$lib": ["src/lib"],
 			"$lib/*": ["src/lib/*"],
+			"$routes": ["src/routes"],
 			"$routes/*": ["src/routes/*"],
+			"$src": ["src"],
 			"$src/*": ["src/*"],
 		},
 		"typeRoots": ["src/@types", "node_modules/@types"]


### PR DESCRIPTION
# Description

This PR implements the following features:

- [x] Upgrade `@sveltejs/kit` to `1.0.1`
- [x] Upgrade `@sveltejs/adapter-static` to `1.0.0`
- [x] Upgrade `vite` to `4.0.0`
- [x] Update path alias configs in tsconfig
- [x] Update tailwind safelist config
- [x] Add `trailingSlashAlways` config (works better with IPFS HTTP Gateway if more pages are added)

## Link to issue

Closes #105 

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

## Test plan (required)

The app should continue to work in local development, built, and published to hosting providers.
