### PR TITLE
Feat: bump webnative and webnative-walletauth to v0.36.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "webnative": "^0.35.1",
-        "webnative-walletauth": "^0.2.0"
+        "webnative": "^0.36.3",
+        "webnative-walletauth": "file:../webnative-walletauth"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0",
@@ -25,6 +25,29 @@
         "typescript": "^4.5.4",
         "undici": "*",
         "vite": "^4.0.0"
+      }
+    },
+    "../webnative-walletauth": {
+      "version": "0.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "@noble/secp256k1": "^1.6.3",
+        "eip1193-provider": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uint8arrays": "^3.1.0"
+      },
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.10.0",
+        "@typescript-eslint/parser": "^5.10.0",
+        "esbuild": "^0.15.7",
+        "eslint": "^8.7.0",
+        "events": "^3.3.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.5.5"
+      },
+      "peerDependencies": {
+        "webnative": "^0.36.3"
       }
     },
     "node_modules/@chainsafe/is-ip": {
@@ -434,37 +457,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "node_modules/@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "node_modules/@libp2p/interface-connection": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.3.tgz",
@@ -623,28 +615,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.4.tgz",
-      "integrity": "sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -679,11 +649,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
@@ -932,14 +897,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1509,14 +1466,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "dependencies": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -1689,25 +1638,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -2343,11 +2273,6 @@
       "engines": {
         "node": ">=10.21.0"
       }
-    },
-    "node_modules/keyvaluestorage-interface": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -3177,11 +3102,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/safe-json-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
-    },
     "node_modules/sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -3706,9 +3626,9 @@
       }
     },
     "node_modules/webnative": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.1.tgz",
-      "integrity": "sha512-ddd4FK0H1rr5rn4bOgtPiYDniM5kR28PdGawLkowzsZDOX2cZhJNxk98fPPuHO9K9+QbEVfR21Mh/RJmF+74Ug==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.3.tgz",
+      "integrity": "sha512-MucN6ydnyY5E8GczuARAWXSOn3+yjXKSLNTIPeJhcFmZpxPBDRfpZ0SpKJjKWtVLNiEaUQibeiKsIYDfij/wIQ==",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",
@@ -3737,19 +3657,8 @@
       }
     },
     "node_modules/webnative-walletauth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.0.tgz",
-      "integrity": "sha512-3A9hpwsH4alSmdlbCJ2gCO3DesPKJSvmh1gUtrf67U1CNRV573dHAchpz+hvzIjCWo4wJwVM7X/KkEJf35dPvQ==",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
-        "eip1193-provider": "^1.0.1",
-        "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.1.0"
-      },
-      "peerDependencies": {
-        "webnative": "^0.35.0"
-      }
+      "resolved": "../webnative-walletauth",
+      "link": true
     },
     "node_modules/wnfs": {
       "version": "0.1.7",
@@ -3761,26 +3670,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -4008,34 +3897,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "requires": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      }
-    },
-    "@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "requires": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "requires": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "@libp2p/interface-connection": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.3.tgz",
@@ -4150,16 +4011,6 @@
         }
       }
     },
-    "@noble/hashes": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.4.tgz",
-      "integrity": "sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA=="
-    },
-    "@noble/secp256k1": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
-      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4185,11 +4036,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@polka/url": {
       "version": "1.0.0-next.21",
@@ -4384,14 +4230,6 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {
@@ -4786,14 +4624,6 @@
         "undici": "^5.12.0"
       }
     },
-    "eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "requires": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
-    },
     "electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -4934,11 +4764,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
-    },
-    "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "formdata-polyfill": {
       "version": "4.0.10",
@@ -5401,11 +5226,6 @@
         "one-webcrypto": "^1.0.3",
         "uint8arrays": "^3.0.0"
       }
-    },
-    "keyvaluestorage-interface": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "kleur": {
       "version": "4.1.5",
@@ -5943,11 +5763,6 @@
         "mri": "^1.1.0"
       }
     },
-    "safe-json-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
-    },
     "sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -6281,9 +6096,9 @@
       "dev": true
     },
     "webnative": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.1.tgz",
-      "integrity": "sha512-ddd4FK0H1rr5rn4bOgtPiYDniM5kR28PdGawLkowzsZDOX2cZhJNxk98fPPuHO9K9+QbEVfR21Mh/RJmF+74Ug==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.3.tgz",
+      "integrity": "sha512-MucN6ydnyY5E8GczuARAWXSOn3+yjXKSLNTIPeJhcFmZpxPBDRfpZ0SpKJjKWtVLNiEaUQibeiKsIYDfij/wIQ==",
       "requires": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",
@@ -6309,14 +6124,19 @@
       }
     },
     "webnative-walletauth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.0.tgz",
-      "integrity": "sha512-3A9hpwsH4alSmdlbCJ2gCO3DesPKJSvmh1gUtrf67U1CNRV573dHAchpz+hvzIjCWo4wJwVM7X/KkEJf35dPvQ==",
+      "version": "file:../webnative-walletauth",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
+        "@typescript-eslint/eslint-plugin": "^5.10.0",
+        "@typescript-eslint/parser": "^5.10.0",
         "eip1193-provider": "^1.0.1",
+        "esbuild": "^0.15.7",
+        "eslint": "^8.7.0",
+        "events": "^3.3.0",
+        "rimraf": "^3.0.2",
         "tweetnacl": "^1.0.3",
+        "typescript": "^4.5.5",
         "uint8arrays": "^3.1.0"
       }
     },
@@ -6330,12 +6150,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "webnative": "^0.36.3",
-        "webnative-walletauth": "fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3"
+        "webnative-walletauth": "^0.2.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0",
@@ -25,6 +25,29 @@
         "typescript": "^4.5.4",
         "undici": "*",
         "vite": "^4.0.0"
+      }
+    },
+    "../webnative-walletauth": {
+      "version": "0.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "@noble/secp256k1": "^1.6.3",
+        "eip1193-provider": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uint8arrays": "^3.1.0"
+      },
+      "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.10.0",
+        "@typescript-eslint/parser": "^5.10.0",
+        "esbuild": "^0.15.7",
+        "eslint": "^8.7.0",
+        "events": "^3.3.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.5.5"
+      },
+      "peerDependencies": {
+        "webnative": "^0.36.3"
       }
     },
     "node_modules/@chainsafe/is-ip": {
@@ -434,37 +457,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "node_modules/@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "node_modules/@libp2p/interface-connection": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.3.tgz",
@@ -623,28 +615,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
-      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -679,11 +649,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
@@ -932,14 +897,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1509,14 +1466,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "dependencies": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -1689,25 +1638,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -2343,11 +2273,6 @@
       "engines": {
         "node": ">=10.21.0"
       }
-    },
-    "node_modules/keyvaluestorage-interface": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -3177,11 +3102,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/safe-json-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
-    },
     "node_modules/sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -3737,19 +3657,8 @@
       }
     },
     "node_modules/webnative-walletauth": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff88f33de60a782088bb44464a49e6e22b681166",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
-        "eip1193-provider": "^1.0.1",
-        "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.1.0"
-      },
-      "peerDependencies": {
-        "webnative": "^0.36.3"
-      }
+      "resolved": "../webnative-walletauth",
+      "link": true
     },
     "node_modules/wnfs": {
       "version": "0.1.7",
@@ -3761,26 +3670,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -4008,34 +3897,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "@json-rpc-tools/provider": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "requires": {
-        "@json-rpc-tools/utils": "^1.7.6",
-        "axios": "^0.21.0",
-        "safe-json-utils": "^1.1.1",
-        "ws": "^7.4.0"
-      }
-    },
-    "@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "requires": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "requires": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "@libp2p/interface-connection": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.3.tgz",
@@ -4150,16 +4011,6 @@
         }
       }
     },
-    "@noble/hashes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
-      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
-    },
-    "@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4185,11 +4036,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@polka/url": {
       "version": "1.0.0-next.21",
@@ -4384,14 +4230,6 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {
@@ -4786,14 +4624,6 @@
         "undici": "^5.12.0"
       }
     },
-    "eip1193-provider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "requires": {
-        "@json-rpc-tools/provider": "^1.5.5"
-      }
-    },
     "electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -4934,11 +4764,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
-    },
-    "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "formdata-polyfill": {
       "version": "4.0.10",
@@ -5401,11 +5226,6 @@
         "one-webcrypto": "^1.0.3",
         "uint8arrays": "^3.0.0"
       }
-    },
-    "keyvaluestorage-interface": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "kleur": {
       "version": "4.1.5",
@@ -5943,11 +5763,6 @@
         "mri": "^1.1.0"
       }
     },
-    "safe-json-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
-    },
     "sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -6309,13 +6124,19 @@
       }
     },
     "webnative-walletauth": {
-      "version": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff88f33de60a782088bb44464a49e6e22b681166",
-      "from": "webnative-walletauth@fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3",
+      "version": "file:../webnative-walletauth",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
+        "@typescript-eslint/eslint-plugin": "^5.10.0",
+        "@typescript-eslint/parser": "^5.10.0",
         "eip1193-provider": "^1.0.1",
+        "esbuild": "^0.15.7",
+        "eslint": "^8.7.0",
+        "events": "^3.3.0",
+        "rimraf": "^3.0.2",
         "tweetnacl": "^1.0.3",
+        "typescript": "^4.5.5",
         "uint8arrays": "^3.1.0"
       }
     },
@@ -6329,12 +6150,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -720,25 +720,25 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.3.tgz",
-      "integrity": "sha512-Mv6KSeJTvHC6RIuLDMPZ8E60zafmyMHjjoXXKwRnD0gdTGdNqnkTd8D9KdJe6zOKKkz7ccldbCtsWW4/XPwgmg==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.8.3.tgz",
+      "integrity": "sha512-32tiLy5PPpt2lquK2p53/5wR+ghAXw0HymIBEezmwmwtzx7Xf36xw3RG3fDYQ9gyzon89T+JRweXgAv/qhhvSQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.0",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.29.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.14.0"
+        "undici": "5.20.0"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -749,6 +749,18 @@
       "peerDependencies": {
         "svelte": "^3.54.0",
         "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@sveltejs/kit/node_modules/magic-string": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+      "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -1434,9 +1446,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.2.0.tgz",
-      "integrity": "sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.0.tgz",
+      "integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
       "dev": true
     },
     "node_modules/didyoumean": {
@@ -3506,9 +3518,9 @@
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -4105,24 +4117,35 @@
       "requires": {}
     },
     "@sveltejs/kit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.3.tgz",
-      "integrity": "sha512-Mv6KSeJTvHC6RIuLDMPZ8E60zafmyMHjjoXXKwRnD0gdTGdNqnkTd8D9KdJe6zOKKkz7ccldbCtsWW4/XPwgmg==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.8.3.tgz",
+      "integrity": "sha512-32tiLy5PPpt2lquK2p53/5wR+ghAXw0HymIBEezmwmwtzx7Xf36xw3RG3fDYQ9gyzon89T+JRweXgAv/qhhvSQ==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.0",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.29.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.14.0"
+        "undici": "5.20.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.29.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+          "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@sveltejs/vite-plugin-svelte": {
@@ -4596,9 +4619,9 @@
       }
     },
     "devalue": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.2.0.tgz",
-      "integrity": "sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.0.tgz",
+      "integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
       "dev": true
     },
     "didyoumean": {
@@ -6041,9 +6064,9 @@
       }
     },
     "undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "webnative": "^0.36.3",
-        "webnative-walletauth": "0.2.1"
+        "webnative-walletauth": "fission-codes/webnative-walletauth#main"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0",
@@ -25,29 +25,6 @@
         "typescript": "^4.5.4",
         "undici": "*",
         "vite": "^4.0.0"
-      }
-    },
-    "../webnative-walletauth": {
-      "version": "0.2.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
-        "eip1193-provider": "^1.0.1",
-        "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.1.0"
-      },
-      "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/parser": "^5.10.0",
-        "esbuild": "^0.15.7",
-        "eslint": "^8.7.0",
-        "events": "^3.3.0",
-        "rimraf": "^3.0.2",
-        "typescript": "^4.5.5"
-      },
-      "peerDependencies": {
-        "webnative": "^0.36.3"
       }
     },
     "node_modules/@chainsafe/is-ip": {
@@ -457,6 +434,37 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@json-rpc-tools/provider": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "axios": "^0.21.0",
+        "safe-json-utils": "^1.1.1",
+        "ws": "^7.4.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
     "node_modules/@libp2p/interface-connection": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.3.tgz",
@@ -615,6 +623,28 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -649,6 +679,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
@@ -909,6 +944,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1478,6 +1521,14 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/eip1193-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "dependencies": {
+        "@json-rpc-tools/provider": "^1.5.5"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -1650,6 +1701,25 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -2285,6 +2355,11 @@
       "engines": {
         "node": ">=10.21.0"
       }
+    },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -3114,6 +3189,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/safe-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+    },
     "node_modules/sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -3669,8 +3749,19 @@
       }
     },
     "node_modules/webnative-walletauth": {
-      "resolved": "../webnative-walletauth",
-      "link": true
+      "version": "0.2.1",
+      "resolved": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff09eda2cb942d10d807f85780a89e84d3d4d522",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "@noble/secp256k1": "^1.6.3",
+        "eip1193-provider": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uint8arrays": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webnative": "^0.36.3"
+      }
     },
     "node_modules/wnfs": {
       "version": "0.1.7",
@@ -3682,6 +3773,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -3909,6 +4020,34 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@json-rpc-tools/provider": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "requires": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "axios": "^0.21.0",
+        "safe-json-utils": "^1.1.1",
+        "ws": "^7.4.0"
+      }
+    },
+    "@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "requires": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "requires": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
     "@libp2p/interface-connection": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.3.tgz",
@@ -4023,6 +4162,16 @@
         }
       }
     },
+    "@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4048,6 +4197,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@polka/url": {
       "version": "1.0.0-next.21",
@@ -4253,6 +4407,14 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {
@@ -4647,6 +4809,14 @@
         "undici": "^5.12.0"
       }
     },
+    "eip1193-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "requires": {
+        "@json-rpc-tools/provider": "^1.5.5"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -4787,6 +4957,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "formdata-polyfill": {
       "version": "4.0.10",
@@ -5249,6 +5424,11 @@
         "one-webcrypto": "^1.0.3",
         "uint8arrays": "^3.0.0"
       }
+    },
+    "keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "kleur": {
       "version": "4.1.5",
@@ -5786,6 +5966,11 @@
         "mri": "^1.1.0"
       }
     },
+    "safe-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+    },
     "sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -6147,19 +6332,13 @@
       }
     },
     "webnative-walletauth": {
-      "version": "file:../webnative-walletauth",
+      "version": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff09eda2cb942d10d807f85780a89e84d3d4d522",
+      "from": "webnative-walletauth@fission-codes/webnative-walletauth#main",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
-        "@typescript-eslint/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/parser": "^5.10.0",
         "eip1193-provider": "^1.0.1",
-        "esbuild": "^0.15.7",
-        "eslint": "^8.7.0",
-        "events": "^3.3.0",
-        "rimraf": "^3.0.2",
         "tweetnacl": "^1.0.3",
-        "typescript": "^4.5.5",
         "uint8arrays": "^3.1.0"
       }
     },
@@ -6173,6 +6352,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "webnative": "^0.36.3",
-        "webnative-walletauth": "fission-codes/webnative-walletauth#main"
+        "webnative-walletauth": "0.2.1-alpha-1"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0",
@@ -3749,9 +3749,9 @@
       }
     },
     "node_modules/webnative-walletauth": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff09eda2cb942d10d807f85780a89e84d3d4d522",
-      "license": "Apache-2.0",
+      "version": "0.2.1-alpha-1",
+      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.1-alpha-1.tgz",
+      "integrity": "sha512-A/6B4zvKtcOizjyGRqM//bjkGIRd7hCncFuZxWucqV2FTODX+dyy65oR3gOmvnBeTK5apMVHkzlAlxTzC8ixuQ==",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
@@ -6332,8 +6332,9 @@
       }
     },
     "webnative-walletauth": {
-      "version": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff09eda2cb942d10d807f85780a89e84d3d4d522",
-      "from": "webnative-walletauth@fission-codes/webnative-walletauth#main",
+      "version": "0.2.1-alpha-1",
+      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.1-alpha-1.tgz",
+      "integrity": "sha512-A/6B4zvKtcOizjyGRqM//bjkGIRd7hCncFuZxWucqV2FTODX+dyy65oR3gOmvnBeTK5apMVHkzlAlxTzC8ixuQ==",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "webnative": "^0.36.3",
-        "webnative-walletauth": "^0.2.1"
+        "webnative-walletauth": "0.2.1"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "webnative": "^0.36.3",
-        "webnative-walletauth": "0.2.1-alpha-1"
+        "webnative-walletauth": "^0.2.2"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0",
@@ -3749,9 +3749,9 @@
       }
     },
     "node_modules/webnative-walletauth": {
-      "version": "0.2.1-alpha-1",
-      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.1-alpha-1.tgz",
-      "integrity": "sha512-A/6B4zvKtcOizjyGRqM//bjkGIRd7hCncFuZxWucqV2FTODX+dyy65oR3gOmvnBeTK5apMVHkzlAlxTzC8ixuQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.2.tgz",
+      "integrity": "sha512-0dETVeUZxj9dxPUwZ5QA5j3Rtqv2CjtXrJ5+0hDVjqJ5zPBnXIrDNuUQ54o8vgzwfzR281rO53ShfughfBwMlA==",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
@@ -6332,9 +6332,9 @@
       }
     },
     "webnative-walletauth": {
-      "version": "0.2.1-alpha-1",
-      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.1-alpha-1.tgz",
-      "integrity": "sha512-A/6B4zvKtcOizjyGRqM//bjkGIRd7hCncFuZxWucqV2FTODX+dyy65oR3gOmvnBeTK5apMVHkzlAlxTzC8ixuQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/webnative-walletauth/-/webnative-walletauth-0.2.2.tgz",
+      "integrity": "sha512-0dETVeUZxj9dxPUwZ5QA5j3Rtqv2CjtXrJ5+0hDVjqJ5zPBnXIrDNuUQ54o8vgzwfzR281rO53ShfughfBwMlA==",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "webnative": "^0.36.3",
-        "webnative-walletauth": "file:../webnative-walletauth"
+        "webnative-walletauth": "fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0",
@@ -25,29 +25,6 @@
         "typescript": "^4.5.4",
         "undici": "*",
         "vite": "^4.0.0"
-      }
-    },
-    "../webnative-walletauth": {
-      "version": "0.2.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
-        "eip1193-provider": "^1.0.1",
-        "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.1.0"
-      },
-      "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/parser": "^5.10.0",
-        "esbuild": "^0.15.7",
-        "eslint": "^8.7.0",
-        "events": "^3.3.0",
-        "rimraf": "^3.0.2",
-        "typescript": "^4.5.5"
-      },
-      "peerDependencies": {
-        "webnative": "^0.36.3"
       }
     },
     "node_modules/@chainsafe/is-ip": {
@@ -457,6 +434,37 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@json-rpc-tools/provider": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "axios": "^0.21.0",
+        "safe-json-utils": "^1.1.1",
+        "ws": "^7.4.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
     "node_modules/@libp2p/interface-connection": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.3.tgz",
@@ -615,6 +623,28 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -649,6 +679,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
@@ -897,6 +932,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1466,6 +1509,14 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/eip1193-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "dependencies": {
+        "@json-rpc-tools/provider": "^1.5.5"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -1638,6 +1689,25 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -2273,6 +2343,11 @@
       "engines": {
         "node": ">=10.21.0"
       }
+    },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -3102,6 +3177,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/safe-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+    },
     "node_modules/sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -3657,8 +3737,19 @@
       }
     },
     "node_modules/webnative-walletauth": {
-      "resolved": "../webnative-walletauth",
-      "link": true
+      "version": "0.2.1",
+      "resolved": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff88f33de60a782088bb44464a49e6e22b681166",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "@noble/secp256k1": "^1.6.3",
+        "eip1193-provider": "^1.0.1",
+        "tweetnacl": "^1.0.3",
+        "uint8arrays": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webnative": "^0.36.3"
+      }
     },
     "node_modules/wnfs": {
       "version": "0.1.7",
@@ -3670,6 +3761,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -3897,6 +4008,34 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@json-rpc-tools/provider": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "requires": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "axios": "^0.21.0",
+        "safe-json-utils": "^1.1.1",
+        "ws": "^7.4.0"
+      }
+    },
+    "@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "requires": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "requires": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
     "@libp2p/interface-connection": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.3.tgz",
@@ -4011,6 +4150,16 @@
         }
       }
     },
+    "@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4036,6 +4185,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@polka/url": {
       "version": "1.0.0-next.21",
@@ -4230,6 +4384,14 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {
@@ -4624,6 +4786,14 @@
         "undici": "^5.12.0"
       }
     },
+    "eip1193-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "requires": {
+        "@json-rpc-tools/provider": "^1.5.5"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -4764,6 +4934,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.1.1.tgz",
       "integrity": "sha512-S2HviLR9UyNbt8R+vU6YeQtL8RliPwez9DQEVba5MAvN3Od+RSgKUSL2+qveOMt3owIeBukKoRu2enoOck5uag=="
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "formdata-polyfill": {
       "version": "4.0.10",
@@ -5226,6 +5401,11 @@
         "one-webcrypto": "^1.0.3",
         "uint8arrays": "^3.0.0"
       }
+    },
+    "keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "kleur": {
       "version": "4.1.5",
@@ -5763,6 +5943,11 @@
         "mri": "^1.1.0"
       }
     },
+    "safe-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+    },
     "sander": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
@@ -6124,19 +6309,13 @@
       }
     },
     "webnative-walletauth": {
-      "version": "file:../webnative-walletauth",
+      "version": "git+ssh://git@github.com/fission-codes/webnative-walletauth.git#ff88f33de60a782088bb44464a49e6e22b681166",
+      "from": "webnative-walletauth@fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3",
       "requires": {
         "@noble/hashes": "^1.1.2",
         "@noble/secp256k1": "^1.6.3",
-        "@typescript-eslint/eslint-plugin": "^5.10.0",
-        "@typescript-eslint/parser": "^5.10.0",
         "eip1193-provider": "^1.0.1",
-        "esbuild": "^0.15.7",
-        "eslint": "^8.7.0",
-        "events": "^3.3.0",
-        "rimraf": "^3.0.2",
         "tweetnacl": "^1.0.3",
-        "typescript": "^4.5.5",
         "uint8arrays": "^3.1.0"
       }
     },
@@ -6150,6 +6329,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "webnative": "^0.36.3",
-    "webnative-walletauth": "0.2.1-alpha-1"
+    "webnative-walletauth": "^0.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "webnative": "^0.36.3",
-    "webnative-walletauth": "file:../webnative-walletauth"
+    "webnative-walletauth": "fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "webnative": "^0.36.3",
-    "webnative-walletauth": "fission-codes/webnative-walletauth#avivash/bump-webnative-to-0.36.3"
+    "webnative-walletauth": "^0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "webnative": "^0.36.3",
-    "webnative-walletauth": "^0.2.1"
+    "webnative-walletauth": "0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "vite": "^4.0.0"
   },
   "dependencies": {
-    "webnative": "^0.35.1",
-    "webnative-walletauth": "^0.2.0"
+    "webnative": "^0.36.3",
+    "webnative-walletauth": "file:../webnative-walletauth"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "webnative": "^0.36.3",
-    "webnative-walletauth": "fission-codes/webnative-walletauth#main"
+    "webnative-walletauth": "0.2.1-alpha-1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "webnative": "^0.36.3",
-    "webnative-walletauth": "0.2.1"
+    "webnative-walletauth": "fission-codes/webnative-walletauth#main"
   }
 }

--- a/src/lib/account-settings.ts
+++ b/src/lib/account-settings.ts
@@ -55,7 +55,7 @@ const archiveOldAvatar = async (): Promise<void> => {
   }
 
   // Find the filename of the old avatar
-  const path = wn.path.directory(...AVATAR_DIR)
+  const path = AVATAR_DIR
   const links = await fs.ls(path)
   const oldAvatarFileName = Object.keys(links).find(key =>
     key.includes(AVATAR_FILE_NAME)

--- a/src/lib/account-settings.ts
+++ b/src/lib/account-settings.ts
@@ -7,6 +7,7 @@ import type { Metadata } from 'webnative/fs/metadata'
 
 import { accountSettingsStore, filesystemStore } from '$src/stores'
 import { addNotification } from '$lib/notifications'
+import { fileToUint8Array } from '$lib/utils'
 
 export type Avatar = {
   cid: string
@@ -29,11 +30,17 @@ interface AvatarFile extends PuttableUnixTree, WNFile {
   }
 }
 
-export const ACCOUNT_SETTINGS_DIR = ['private', 'settings']
-const AVATAR_DIR = [...ACCOUNT_SETTINGS_DIR, 'avatars']
-const AVATAR_ARCHIVE_DIR = [...AVATAR_DIR, 'archive']
+export const ACCOUNT_SETTINGS_DIR = wn.path.directory('private', 'settings')
+const AVATAR_DIR = wn.path.combine(
+  ACCOUNT_SETTINGS_DIR,
+  wn.path.directory('avatars')
+)
+const AVATAR_ARCHIVE_DIR = wn.path.combine(
+  AVATAR_DIR,
+  wn.path.directory('archive')
+)
 const AVATAR_FILE_NAME = 'avatar'
-const FILE_SIZE_LIMIT = 5
+const FILE_SIZE_LIMIT = 20
 
 /**
  * Move old avatar to the archive directory
@@ -42,7 +49,7 @@ const archiveOldAvatar = async (): Promise<void> => {
   const fs = getStore(filesystemStore)
 
   // Return if user has not uploaded an avatar yet
-  const avatarDirExists = await fs.exists(wn.path.file(...AVATAR_DIR))
+  const avatarDirExists = await fs.exists(AVATAR_DIR)
   if (!avatarDirExists) {
     return
   }
@@ -59,8 +66,11 @@ const archiveOldAvatar = async (): Promise<void> => {
   }`
 
   // Move old avatar to archive dir
-  const fromPath = wn.path.file(...AVATAR_DIR, oldAvatarFileName)
-  const toPath = wn.path.file(...AVATAR_ARCHIVE_DIR, archiveFileName)
+  const fromPath = wn.path.combine(AVATAR_DIR, wn.path.file(oldAvatarFileName))
+  const toPath = wn.path.combine(
+    AVATAR_ARCHIVE_DIR,
+    wn.path.file(archiveFileName)
+  )
   await fs.mv(fromPath, toPath)
 
   // Announce the changes to the server
@@ -78,7 +88,7 @@ export const getAvatarFromWNFS = async (): Promise<void> => {
     const fs = getStore(filesystemStore)
 
     // If the avatar dir doesn't exist, silently fail and let the UI handle it
-    const avatarDirExists = await fs.exists(wn.path.file(...AVATAR_DIR))
+    const avatarDirExists = await fs.exists(AVATAR_DIR)
     if (!avatarDirExists) {
       accountSettingsStore.update(store => ({
         ...store,
@@ -88,7 +98,7 @@ export const getAvatarFromWNFS = async (): Promise<void> => {
     }
 
     // Find the file that matches the AVATAR_FILE_NAME
-    const path = wn.path.directory(...AVATAR_DIR)
+    const path = AVATAR_DIR
     const links = await fs.ls(path)
     const avatarName = Object.keys(links).find(key =>
       key.includes(AVATAR_FILE_NAME)
@@ -103,7 +113,9 @@ export const getAvatarFromWNFS = async (): Promise<void> => {
       return
     }
 
-    const file = await fs.get(wn.path.file(...AVATAR_DIR, `${avatarName}`))
+    const file = await fs.get(
+      wn.path.combine(AVATAR_DIR, wn.path.file(`${avatarName}`))
+    )
 
     // The CID for private files is currently located in `file.header.content`
     const cid = (file as AvatarFile).header.content.toString()
@@ -167,7 +179,10 @@ export const uploadAvatarToWNFS = async (image: File): Promise<void> => {
     )
 
     // Create a sub directory and add the avatar
-    await fs.write(wn.path.file(...AVATAR_DIR, updatedImage.name), updatedImage)
+    await fs.write(
+      wn.path.combine(AVATAR_DIR, wn.path.file(updatedImage.name)),
+      await fileToUint8Array(updatedImage)
+    )
 
     // Announce the changes to the server
     await fs.publish()

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,6 @@
 import { get as getStore } from 'svelte/store'
 import { goto } from '$app/navigation'
-import * as wn from 'webnative'
+import type * as wn from 'webnative'
 import * as walletauth from 'webnative-walletauth'
 
 import { filesystemStore, sessionStore } from '../stores'

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -53,7 +53,7 @@ const handleProgram = async (program: wn.Program) => {
 
   if (program.session) {
     // Create directory for Account Settings
-    await program.session.fs.mkdir(wn.path.directory(...ACCOUNT_SETTINGS_DIR))
+    await program.session.fs.mkdir(ACCOUNT_SETTINGS_DIR)
 
     // ✅ Authenticated
     sessionStore.update(state => ({

--- a/src/routes/gallery/lib/gallery.ts
+++ b/src/routes/gallery/lib/gallery.ts
@@ -31,8 +31,8 @@ type Link = {
 }
 
 export const GALLERY_DIRS = {
-  [ AREAS.PUBLIC ]: [ 'public', 'gallery' ],
-  [ AREAS.PRIVATE ]: [ 'private', 'gallery' ]
+  [AREAS.PUBLIC]: wn.path.directory('public', 'gallery'),
+  [AREAS.PRIVATE]: wn.path.directory('private', 'gallery')
 }
 const FILE_SIZE_LIMIT = 20
 
@@ -44,20 +44,20 @@ const FILE_SIZE_LIMIT = 20
 
 export const initializeFilesystem = async (fs: FileSystem): Promise<void> => {
   const publicPathExists = await fs.exists(
-    wn.path.file(...GALLERY_DIRS[ AREAS.PUBLIC ])
-  );
+    GALLERY_DIRS[AREAS.PUBLIC]
+  )
   const privatePathExists = await fs.exists(
-    wn.path.file(...GALLERY_DIRS[ AREAS.PRIVATE ])
-  );
+    GALLERY_DIRS[AREAS.PRIVATE]
+  )
 
   if (!publicPathExists) {
-    await fs.mkdir(wn.path.directory(...GALLERY_DIRS[ AREAS.PUBLIC ]));
+    await fs.mkdir(GALLERY_DIRS[AREAS.PUBLIC])
   }
 
   if (!privatePathExists) {
-    await fs.mkdir(wn.path.directory(...GALLERY_DIRS[ AREAS.PRIVATE ]));
+    await fs.mkdir(GALLERY_DIRS[AREAS.PRIVATE])
   }
-};
+}
 
 /**
  * Get images from the user's WNFS and construct the `src` value for the images
@@ -72,15 +72,15 @@ export const getImagesFromWNFS: () => Promise<void> = async () => {
     const fs = getStore(filesystemStore)
 
     // Set path to either private or public gallery dir
-    const path = wn.path.directory(...GALLERY_DIRS[ selectedArea ])
+    const path = GALLERY_DIRS[selectedArea]
 
     // Get list of links for files in the gallery dir
     const links = await fs.ls(path)
 
     let images = await Promise.all(
-      Object.entries(links).map(async ([ name ]) => {
+      Object.entries(links).map(async ([name]) => {
         const file = await fs.get(
-          wn.path.file(...GALLERY_DIRS[ selectedArea ], `${name}`)
+          wn.path.combine(GALLERY_DIRS[selectedArea], wn.path.file(`${name}`))
         )
 
         if (!isFile(file)) return null
@@ -92,7 +92,7 @@ export const getImagesFromWNFS: () => Promise<void> = async () => {
           : (file as PublicFile).cid.toString()
 
         // Create a blob to use as the image `src`
-        const blob = new Blob([ file.content ])
+        const blob = new Blob([file.content])
         const src = URL.createObjectURL(blob)
 
         const ctime = isPrivate
@@ -104,7 +104,7 @@ export const getImagesFromWNFS: () => Promise<void> = async () => {
           ctime,
           name,
           private: isPrivate,
-          size: (links[ name ] as Link).size,
+          size: (links[name] as Link).size,
           src
         }
       })
@@ -120,11 +120,11 @@ export const getImagesFromWNFS: () => Promise<void> = async () => {
       ...store,
       ...(isPrivate
         ? {
-          privateImages: images
-        }
+            privateImages: images
+          }
         : {
-          publicImages: images
-        }),
+            publicImages: images
+          }),
       loading: false
     }))
   } catch (error) {
@@ -155,7 +155,7 @@ export const uploadImageToWNFS: (
 
     // Reject the upload if the image already exists in the directory
     const imageExists = await fs.exists(
-      wn.path.file(...GALLERY_DIRS[ selectedArea ], image.name)
+      wn.path.combine(GALLERY_DIRS[ selectedArea ], wn.path.file(image.name))
     )
     if (imageExists) {
       throw new Error(`${image.name} image already exists`)
@@ -163,7 +163,7 @@ export const uploadImageToWNFS: (
 
     // Create a sub directory and add some content
     await fs.write(
-      wn.path.file(...GALLERY_DIRS[ selectedArea ], image.name),
+      wn.path.combine(GALLERY_DIRS[ selectedArea ], wn.path.file(image.name)),
       await fileToUint8Array(image)
     )
 
@@ -189,12 +189,14 @@ export const deleteImageFromWNFS: (
     const fs = getStore(filesystemStore)
 
     const imageExists = await fs.exists(
-      wn.path.file(...GALLERY_DIRS[ selectedArea ], name)
+      wn.path.combine(GALLERY_DIRS[selectedArea], wn.path.file(name))
     )
 
     if (imageExists) {
       // Remove images from server
-      await fs.rm(wn.path.file(...GALLERY_DIRS[ selectedArea ], name))
+      await fs.rm(
+        wn.path.combine(GALLERY_DIRS[selectedArea], wn.path.file(name))
+      )
 
       // Announce the changes to the server
       await fs.publish()


### PR DESCRIPTION
# Description

- Bump `webnative` to `0.36.3`(also updated inside [webnative-walletauth](https://github.com/fission-codes/webnative-walletauth/pull/17))
- Update account-settings and gallery directory definitions to match WAT(using `wn.path.directory`/`wn.patch.combine`)

When testing this, I was initially seeing a `Signature does not match content` error any time I tried to `publish` something to the file system, but the error seems to be resolved now... so i'm not sure if it was an issue with the Fission server 🤔 

I'll merge these [walletauth-react PR](https://github.com/webnative-examples/walletauth-react/pull/5) once this one has been merged

## Link to issue

https://github.com/orgs/fission-codes/projects/14/views/26?pane=issue&itemId=21175565

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)

